### PR TITLE
feat: 견적 요청(일반 유저) API 구현

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import yaml from "yaml";
 import path from "path";
 import authRouter from "./routes/auth.router";
 import profileRouter from "./routes/profile.router";
+import estimateReqRouter from "./routes/estimateReq.router";
 import { errorHandler } from "./middlewares/errorHandler";
 
 const app = express();
@@ -23,6 +24,7 @@ app.use(passport.initialize());
 
 app.use("/auth", authRouter);
 app.use("/profile", profileRouter);
+app.use("/", estimateReqRouter);
 
 app.use(
   "/api-docs",

--- a/src/controllers/estimateReq.controller.ts
+++ b/src/controllers/estimateReq.controller.ts
@@ -1,0 +1,78 @@
+import { Request, Response } from "express";
+import estimateReqService from "../services/estimateReq.service";
+import { asyncHandler } from "../utils/asyncHandler";
+import { CustomError } from "../utils/customError";
+
+// 주소 등록
+const createAddress = asyncHandler(async (req: Request, res: Response) => {
+  const { postalCode, street, detail, region, district } = req.body;
+
+  if (!postalCode || !street || !region || !district) {
+    throw new CustomError(400, "필수 주소 정보가 누락되었습니다.");
+  }
+
+  const address = await estimateReqService.createAddress({
+    postalCode,
+    street,
+    detail,
+    region,
+    district
+  });
+
+  res.status(201).json(address);
+});
+
+// 고객 주소 연결
+const linkCustomerAddress = asyncHandler(async (req: Request, res: Response) => {
+  const { customerId, addressId, role } = req.body;
+
+  if (!customerId || !addressId || !role) {
+    throw new CustomError(400, "필수 주소 정보가 누락되었습니다.");
+  }
+
+  const link = await estimateReqService.linkCustomerAddress({ customerId, addressId, role });
+  res.status(201).json(link);
+});
+
+// 고객 주소 목록 조회
+const getCustomerAddressesByRole = asyncHandler(async (req: Request, res: Response) => {
+  const { role, customerId } = req.query;
+
+  if (!customerId || typeof role !== "string") {
+    throw new CustomError(400, "필수 요청 정보가 누락되었습니다.");
+  }
+
+  const addresses = await estimateReqService.getCustomerAddressesByRole(customerId as string, role);
+  res.status(200).json(addresses);
+});
+
+// 견적 요청 생성
+const createEstimateRequest = asyncHandler(async (req: Request, res: Response) => {
+  const { customerId, moveType, moveDate, fromAddressId, toAddressId } = req.body;
+
+  if (!customerId || !moveType || !moveDate || !fromAddressId || !toAddressId) {
+    throw new CustomError(400, "필수 요청 정보가 누락되었습니다.");
+  }
+
+  if (fromAddressId === toAddressId) {
+    throw new CustomError(400, "출발지와 도착지는 서로 달라야 합니다.");
+  }
+
+  const request = await estimateReqService.createEstimateRequest({
+    customerId,
+    moveType,
+    moveDate: new Date(moveDate),
+    fromAddressId,
+    toAddressId,
+    status: "PENDING"
+  });
+
+  res.status(201).json(request);
+});
+
+export default {
+  createAddress,
+  linkCustomerAddress,
+  getCustomerAddressesByRole,
+  createEstimateRequest
+};

--- a/src/repositories/estimateReq.repository.ts
+++ b/src/repositories/estimateReq.repository.ts
@@ -1,0 +1,68 @@
+import prisma from "../config/prisma";
+import type { AddressRole } from "@prisma/client";
+import { CreateAddressInput, LinkCustomerAddressInput, CreateEstimateRequestInput } from "../types/estimateReq.type";
+
+// DB에 주소 등록
+async function createAddress(data: CreateAddressInput) {
+  return prisma.address.create({ data });
+}
+
+// 주소 중복 체크
+async function findAddressByFields(postalCode: string, street: string, detail?: string | null) {
+  return prisma.address.findFirst({
+    where: {
+      postalCode,
+      street,
+      ...(detail !== undefined ? { detail } : {})
+    }
+  });
+}
+
+// 고객(customer) 테이블에 연결(FROM, TO)
+async function linkCustomerAddress(data: LinkCustomerAddressInput) {
+  return prisma.customerAddress.create({ data });
+}
+
+// 고객(customer) 테이블에서 조회(FROM, TO)
+async function getCustomerAddressesByRole(customerId: string, role: AddressRole) {
+  return prisma.customerAddress.findMany({
+    where: {
+      customerId,
+      role,
+      deletedAt: null
+    },
+    include: {
+      address: true
+    }
+  });
+}
+
+// 견적 요청
+async function createEstimateRequest(data: CreateEstimateRequestInput) {
+  return prisma.estimateRequest.create({ data });
+}
+
+// 활성 견적 요청 조회
+async function findActiveEstimateRequest(customerId: string) {
+  return prisma.estimateRequest.findFirst({
+    where: {
+      customerId,
+      deletedAt: null,
+      moveDate: {
+        gt: new Date()
+      },
+      status: {
+        in: ["PENDING", "APPROVED"]
+      }
+    }
+  });
+}
+
+export default {
+  createAddress,
+  findAddressByFields,
+  linkCustomerAddress,
+  getCustomerAddressesByRole,
+  createEstimateRequest,
+  findActiveEstimateRequest
+};

--- a/src/routes/estimateReq.router.ts
+++ b/src/routes/estimateReq.router.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import estimateReqController from "../controllers/estimateReq.controller";
+
+const router = express.Router();
+
+router.post("/address", estimateReqController.createAddress);
+router
+  .route("/customer/address")
+  .post(estimateReqController.linkCustomerAddress)
+  .get(estimateReqController.getCustomerAddressesByRole);
+router.post("/customer/estimate-request", estimateReqController.createEstimateRequest);
+
+export default router;

--- a/src/services/estimateReq.service.ts
+++ b/src/services/estimateReq.service.ts
@@ -1,0 +1,43 @@
+import { AddressRole } from "@prisma/client";
+import estimateRepRepository from "../repositories/estimateReq.repository";
+import { CreateAddressInput, LinkCustomerAddressInput, CreateEstimateRequestInput } from "../types/estimateReq.type";
+
+// DB에 주소 등록
+async function createAddress(data: CreateAddressInput) {
+  const { postalCode, street, detail } = data;
+
+  const existing = await estimateRepRepository.findAddressByFields(postalCode, street, detail);
+  if (existing) return existing;
+
+  return estimateRepRepository.createAddress(data);
+}
+
+// 고객 주소 연결
+async function linkCustomerAddress(data: LinkCustomerAddressInput) {
+  return estimateRepRepository.linkCustomerAddress(data);
+}
+
+// 고객 주소 목록 조회
+async function getCustomerAddressesByRole(customerId: string, role: string) {
+  return estimateRepRepository.getCustomerAddressesByRole(customerId, role as AddressRole);
+}
+
+// 견적 요청 생성
+async function createEstimateRequest(data: CreateEstimateRequestInput) {
+  const { customerId } = data;
+
+  const active = await estimateRepRepository.findActiveEstimateRequest(customerId);
+  if (active) {
+    throw new Error("현재 진행 중인 이사 견적이 있습니다.");
+  }
+  // TODO: 최대 5명의 기사 요청 제한
+
+  return estimateRepRepository.createEstimateRequest(data);
+}
+
+export default {
+  createAddress,
+  linkCustomerAddress,
+  getCustomerAddressesByRole,
+  createEstimateRequest
+};

--- a/src/types/estimateReq.type.ts
+++ b/src/types/estimateReq.type.ts
@@ -1,0 +1,27 @@
+import { AddressRole, MoveType, RegionType, RequestStatus } from "@prisma/client";
+
+// 주소 타입
+export type CreateAddressInput = {
+  postalCode: string;
+  street: string;
+  detail?: string;
+  region: RegionType;
+  district: string;
+};
+
+// 고객 주소 타입
+export type LinkCustomerAddressInput = {
+  customerId: string;
+  addressId: string;
+  role: AddressRole;
+};
+
+// 견적 요청 타입
+export type CreateEstimateRequestInput = {
+  customerId: string;
+  moveType: MoveType; // 'HOME' | 'OFFICE' | 'SMALL'
+  moveDate: Date;
+  fromAddressId: string;
+  toAddressId: string;
+  status: RequestStatus; // 기본값: PENDING
+};


### PR DESCRIPTION
## 📝작업 내용
- 견적 요청 API 구현 (POST /customer/estimate-request)
   - 고객이 이사 견적을 요청하는 기능 추가
   - 요청 시 활성화된 진행 중 견적 여부를 체크하여 중복 요청 방지
   - 출발지(fromAddressId)와 도착지(toAddressId)는 동일할 수 없도록 검증 추가
- 주소 등록 (POST /address)
   - 중복된 주소는 재사용하도록 중복 체크 로직 추가
- 고객 주소 연결 (POST /customer/address)
   - 고객과 주소를 역할(FROM, TO, EXTRA)에 따라 연결
- 고객 주소 조회 (GET /customer/address?customerId=&role=)
   - 특정 고객의 주소를 역할별로 조회 가능

**TODO**
  - 기사님 견적 응답 API와 연동
  - 한 번의 요청당 기사님 5명 제한 추가 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
