### PR TITLE
fix:유효성 검사 추가, 액세스토큰에 정보추가, auth/me/detail 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "jsonwebtoken": "^9.0.2",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
@@ -949,6 +950,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -1199,6 +1218,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "jsonwebtoken": "^9.0.2",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",

--- a/src/controllers/profile.controller.ts
+++ b/src/controllers/profile.controller.ts
@@ -21,13 +21,19 @@ const createCustomerProfile = asyncHandler(async (req: Request, res: Response) =
 
   const { profileImage, moveType, currentArea } = req.body;
 
-  const profile = await profileService.createCustomerProfile(authUserId, {
+  const { profile, accessToken, refreshToken } = await profileService.createCustomerProfile(authUserId, {
     profileImage,
     moveType,
     currentArea
   });
 
-  res.status(201).json(profile);
+  res.cookie("refreshToken", refreshToken, {
+    httpOnly: true,
+    path: "/",
+    sameSite: "none",
+    secure: true
+  });
+  res.status(201).json({ profile, accessToken });
 });
 
 // 고객 프로필 수정
@@ -78,7 +84,7 @@ const createDriverProfile = asyncHandler(async (req: Request, res: Response) => 
 
   const { profileImage, nickname, career, shortIntro, detailIntro, moveType, serviceAreas } = req.body;
 
-  const result = await profileService.createDriverProfile(authUserId, {
+  const { profile, accessToken, refreshToken } = await profileService.createDriverProfile(authUserId, {
     profileImage,
     nickname,
     career,
@@ -88,7 +94,9 @@ const createDriverProfile = asyncHandler(async (req: Request, res: Response) => 
     serviceAreas
   });
 
-  res.status(201).json(result);
+  res.cookie("refreshToken", refreshToken, { httpOnly: true, path: "/", sameSite: "none", secure: true });
+
+  res.status(201).json({ profile, accessToken });
 });
 
 // 기사 프로필 수정

--- a/src/middlewares/passport/jwtStrategy.ts
+++ b/src/middlewares/passport/jwtStrategy.ts
@@ -6,8 +6,10 @@ import { AuthUserWithProfile } from "../../repositories/auth.repository";
 import authService, { TokenUserPayload } from "../../services/auth.service";
 
 interface JwtPayload {
-  userId: AuthUser["id"];
+  id: AuthUser["id"];
   userType: UserType;
+  customerId?: string;
+  driverId?: string;
 }
 
 if (!process.env.JWT_SECRET) {
@@ -37,18 +39,12 @@ const refreshTokenOptions: StrategyOptions = {
 
 async function jwtVerify(payload: JwtPayload, done: VerifiedCallback) {
   try {
-    const user: AuthUserWithProfile | null = await authService.getUserById(payload.userId);
+    const user: AuthUserWithProfile | null = await authService.getUserById(payload.id);
 
     if (!user) {
       return done(null, false);
     }
-
-    const userPayload: TokenUserPayload = {
-      id: user.id,
-      userType: user.userType
-    };
-
-    return done(null, userPayload);
+    return done(null, payload);
   } catch (error) {
     return done(error, false);
   }

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -5,7 +5,7 @@ import { AuthProvider } from "@prisma/client";
 
 export type AuthUserWithProfile = AuthUser & {
   customer?: Customer | null;
-  driver?: Pick<Driver, "nickname"> | null;
+  driver?: Pick<Driver, "id" | "nickname"> | null;
 };
 
 // 이메일로 AuthUser 조회 (프로필 포함)
@@ -14,9 +14,7 @@ async function findByEmail(email: string): Promise<AuthUserWithProfile | null> {
     where: { email },
     include: {
       customer: true,
-      driver: {
-        select: { nickname: true }
-      }
+      driver: { select: { id: true, nickname: true } }
     }
   });
 }
@@ -27,9 +25,7 @@ async function findById(id: string): Promise<AuthUserWithProfile | null> {
     where: { id },
     include: {
       customer: true,
-      driver: {
-        select: { nickname: true }
-      }
+      driver: { select: { id: true, nickname: true } }
     }
   });
 }

--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -1,14 +1,13 @@
 import express from "express";
-import authController from "../controllers/auth.controller";
+import authController, { authLimiter } from "../controllers/auth.controller";
 import passport from "../config/passport";
 
 const authRouter = express.Router();
 
 // 회원가입
-authRouter.post("/signup", authController.signUp);
-
+authRouter.post("/signup", authLimiter, authController.signUp);
 // 로그인
-authRouter.post("/login", authController.logIn);
+authRouter.post("/login", authLimiter, authController.logIn);
 
 // 로그아웃
 authRouter.post("/logout", authController.logOut);
@@ -19,11 +18,18 @@ authRouter.get("/social/:provider", authController.startSocialLogin);
 // 소셜 로그인 콜백
 authRouter.get("/social/:provider/callback", authController.socialLoginCallback);
 
-// 로그인된 유저 인증 정보 조회
+// 로그인된 유저 인증(최소) 정보 조회
 authRouter.get(
   "/me",
   passport.authenticate("access-token", { session: false, failWithError: true }),
   authController.getMe
+);
+
+// 로그인된 유저 자세한 정보 조회
+authRouter.get(
+  "/me/detail",
+  passport.authenticate("access-token", { session: false, failWithError: true }),
+  authController.getUserById
 );
 
 // 액세스 토큰 재발급


### PR DESCRIPTION
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 백엔드 유효성 검사 및 로그인 회원가입 횟수 제한 라이브러리 추가
(API 요청 횟수로 카운팅하는데 개발단계니까 로그인 및 회원가입 요청을 한시간에 50회로 설정하였음)
2. 액세스 토큰에 id, 유저타입 외에 드라이버id, 혹은 커스토머id 를 추가
3. 인증 API에 auth/me/detail 을 추가하여 로그인 된 유저의 자세한 정보 조회 API 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
