### PR TITLE
[기능] 기사 견적 관련 API 4종 구현

### DIFF
--- a/driver.http
+++ b/driver.http
@@ -1,7 +1,7 @@
 @customer_access_token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImNtZGVjemwxdjAwMDBzNm00Z3c2NnJzbHgiLCJ1c2VyVHlwZSI6IkNVU1RPTUVSIiwiY3VzdG9tZXJJZCI6ImNtZGVkMW5kaTAwMDRzNm00dDdic2ppemUiLCJpYXQiOjE3NTMyMzYyMTEsImV4cCI6MTc1MzIzOTgxMX0.N5a827RNhgtR2NbtZQvvSWpltvS3RwX6csrTNYFVifk
-@accessToken_driver = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImNtZGZiajU1NzAwMDBjOTk4eTN0MHV5ejEiLCJ1c2VyVHlwZSI6IkRSSVZFUiIsImRyaXZlcklkIjoiY21kZmJycDN5MDAwMGM5b3d4YnFxcnR3aSIsImlhdCI6MTc1MzI1NTE4MSwiZXhwIjoxNzUzMjU4NzgxfQ.AGDoaxOIQFxNI5Rock37pO6gdfKmjPSnqQjNdfB_4fE
+@accessToken_driver = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImNtZGZiajU1NzAwMDBjOTk4eTN0MHV5ejEiLCJ1c2VyVHlwZSI6IkRSSVZFUiIsImRyaXZlcklkIjoiY21kZmJycDN5MDAwMGM5b3d4YnFxcnR3aSIsImlhdCI6MTc1MzI2MTI5MCwiZXhwIjoxNzUzMjY0ODkwfQ.RXeuHQVxj3s_6cZ7pS7rbWc_gseTcDZ0Xn1kEatiHms
 
-### 1. 고객 계정으로 견적 요청 생성
+### (보람님)고객 계정으로 견적 요청 생성
 POST http://localhost:4000/customer/estimate-request
 Content-Type: application/json
 Authorization: Bearer {{customer_access_token}}
@@ -13,7 +13,7 @@ Authorization: Bearer {{customer_access_token}}
   "toAddressId": "cmde89skl0003v92dojwiie1d"
 }
 
-### 특정 기사님에게 "지정 견적 요청"
+### (보람님)특정 기사님에게 "지정 견적 요청"
 POST http://localhost:4000/customer/estimate-request/designated
 Content-Type: application/json
 Authorization: Bearer {{customer_access_token}}
@@ -22,12 +22,12 @@ Authorization: Bearer {{customer_access_token}}
   "driverId": "cmdfbrp3y0000c9owxbqqrtwi"
 }
 
-### 기사님이 받은 견적 요청 리스트 조회
+### 1. 기사님이 받은 견적 요청 리스트 조회
 GET http://localhost:4000/driver/estimate-requests
 Content-Type: application/json
 Authorization: Bearer {{accessToken_driver}}
 
-### 4. 기사님이 견적 보내기
+### 2. 기사님이 견적 보내기
 # 견적요청 ID는 위에서 받은 것을 사용
 POST http://localhost:4000/driver/estimate-requests/cmdfce4980006c9ow64zjc7c4/estimates
 Content-Type: application/json
@@ -37,3 +37,28 @@ Authorization: Bearer {{accessToken_driver}}
   "price": 200000,
   "message": "안녕하세요! 경력 5년의 기사입니다. 안전하고 깔끔하게 진행드리겠습니다."
 }
+
+### 3. 기사님이 견적 요청 반려하기
+POST http://localhost:4000/driver/estimate-requests/cmdfce4980006c9ow64zjc7c4/reject
+Authorization: Bearer {{accessToken_driver}}
+Content-Type: application/json
+
+{
+  "reason": "일정이 맞지 않습니다."
+}
+
+### 4. 기사님이 보낸 견적 리스트 조회
+GET http://localhost:4000/driver/estimates
+Content-Type: application/json
+Authorization: Bearer {{accessToken_driver}}
+
+### 5. 기사님이 보낸 견적 상세 조회
+# 아래 ID는 실제 견적 ID로 바꿔야 함
+GET http://localhost:4000/driver/estimates/cmdfn0xzc000ac9owk6kbfg9c
+Content-Type: application/json
+Authorization: Bearer {{accessToken_driver}}
+
+### 6. 기사님이 반려한 견적 요청 리스트 조회
+GET http://localhost:4000/driver/estimate-requests/rejected
+Content-Type: application/json
+Authorization: Bearer {{accessToken_driver}}

--- a/src/controllers/driver.controller.ts
+++ b/src/controllers/driver.controller.ts
@@ -88,6 +88,54 @@ const createEstimate = asyncHandler(async (req, res) => {
   res.status(201).json(estimate);
 });
 
+const rejectEstimateRequest = asyncHandler(async (req, res) => {
+  const driverId = req.user?.driverId;
+  const { requestId } = req.params;
+  const { reason } = req.body; // 반려사유
+
+  if (!driverId) return res.status(401).json({ message: "Driver not authenticated" });
+
+  // 이미 해당 기사님이 이 요청에 대해 견적(Estimate)을 제출했는지 확인
+  const estimate = await driverService.findEstimateByDriverAndRequest(driverId, requestId);
+  if (!estimate) {
+    return res.status(404).json({ message: "기사님의 견적이 존재하지 않습니다." });
+  }
+
+  // 이미 반려된 경우 방지
+  if (estimate.status === "REJECTED") {
+    return res.status(409).json({ message: "이미 반려 처리된 견적입니다." });
+  }
+
+  // 견적 상태와 반려사유 업데이트
+  const updated = await driverService.rejectEstimate(estimate.id, reason);
+
+  res.status(200).json(updated);
+});
+
+const getMyEstimates = asyncHandler(async (req, res) => {
+  const driverId = req.user?.driverId;
+  if (!driverId) return res.status(401).json({ message: "Driver not authenticated" });
+  const estimates = await driverService.getMyEstimates(driverId);
+  res.status(200).json(estimates);
+});
+
+const getEstimateDetail = asyncHandler(async (req, res) => {
+  const driverId = req.user?.driverId;
+  const { estimateId } = req.params;
+  if (!driverId) return res.status(401).json({ message: "Driver not authenticated" });
+  const detail = await driverService.getEstimateDetail(driverId, estimateId);
+  if (!detail) return res.status(404).json({ message: "견적을 찾을 수 없습니다." });
+  res.status(200).json(detail);
+});
+
+const getRejectedEstimateRequests = asyncHandler(async (req: Request, res: Response) => {
+  const driverId = req.user?.driverId;
+  if (!driverId) return res.status(401).json({ message: "Driver not authenticated" });
+
+  const rejectedEstimates = await driverService.getRejectedEstimateRequests(driverId);
+  res.status(200).json(rejectedEstimates);
+});
+
 export default {
   getAllDriversAuth,
   getAllDrivers,
@@ -96,5 +144,9 @@ export default {
   getDriverReviews,
   updateDriver,
   getEstimateRequestsForDriver,
-  createEstimate
+  createEstimate,
+  rejectEstimateRequest,
+  getMyEstimates,
+  getEstimateDetail,
+  getRejectedEstimateRequests
 };

--- a/src/repositories/driver.repository.ts
+++ b/src/repositories/driver.repository.ts
@@ -86,6 +86,11 @@ async function getDriverReviews(id: string, page: number) {
   return reviews;
 }
 
+//기사님 프로필 업데이트
+async function updateDriver(id: string, data: EditDataType) {
+  return await prisma.authUser.update({ where: { id }, data });
+}
+
 // 기사님이 받은 견적 요청 리스트 조회 (고객이 기사에게 직접 요청한 것만)
 async function getEstimateRequestsForDriver(driverId: string) {
   // 지정 견적 요청 (DesignatedDriver)만 조회
@@ -104,9 +109,75 @@ async function getEstimateRequestsForDriver(driverId: string) {
   });
 }
 
-//기사님 프로필 업데이트
-async function updateDriver(id: string, data: EditDataType) {
-  return await prisma.authUser.update({ where: { id }, data });
+async function findEstimateByDriverAndRequest(driverId: string, estimateRequestId: string) {
+  return prisma.estimate.findFirst({
+    where: { driverId, estimateRequestId, deletedAt: null }
+  });
+}
+
+async function createEstimate(data: { driverId: string; estimateRequestId: string; price: number; comment?: string }) {
+  return prisma.estimate.create({ data });
+}
+
+async function rejectEstimate(estimateId: string, reason: string) {
+  return prisma.estimate.update({
+    where: { id: estimateId },
+    data: {
+      status: "REJECTED",
+      rejectReason: reason
+    }
+  });
+}
+
+async function getMyEstimates(driverId: string) {
+  // 기사님이 보낸 모든 견적 리스트 반환
+  return await prisma.estimate.findMany({
+    where: { driverId, deletedAt: null },
+    include: {
+      estimateRequest: true
+    }
+  });
+}
+
+async function getEstimateDetail(driverId: string, estimateId: string) {
+  // 기사 본인이 보낸 견적만 조회, 상세 정보 포함
+  return await prisma.estimate.findFirst({
+    where: { id: estimateId, driverId, deletedAt: null },
+    include: {
+      estimateRequest: {
+        include: {
+          customer: true,
+          fromAddress: true,
+          toAddress: true
+        }
+      }
+    }
+  });
+}
+
+async function getRejectedEstimateRequests(driverId: string) {
+  return await prisma.estimate.findMany({
+    where: {
+      driverId,
+      status: "REJECTED",
+      deletedAt: null
+    },
+    include: {
+      estimateRequest: {
+        include: {
+          customer: {
+            include: {
+              authUser: {
+                select: { name: true }
+              }
+            }
+          },
+          fromAddress: true,
+          toAddress: true
+        }
+      }
+    }
+  });
 }
 
 export default {
@@ -114,5 +185,11 @@ export default {
   getDriverById,
   getDriverReviews,
   updateDriver,
-  getEstimateRequestsForDriver
+  getEstimateRequestsForDriver,
+  findEstimateByDriverAndRequest,
+  createEstimate,
+  rejectEstimate,
+  getMyEstimates,
+  getEstimateDetail,
+  getRejectedEstimateRequests
 };

--- a/src/routes/driverPrivate.router.ts
+++ b/src/routes/driverPrivate.router.ts
@@ -10,4 +10,17 @@ driverPrivateRouter.get("/estimate-requests", requiredAuth, driverController.get
 
 driverPrivateRouter.post("/estimate-requests/:requestId/estimates", requiredAuth, driverController.createEstimate);
 
+driverPrivateRouter.post("/estimate-requests/:requestId/reject", requiredAuth, driverController.rejectEstimateRequest);
+
+driverPrivateRouter.get("/estimates", requiredAuth, driverController.getMyEstimates);
+
+driverPrivateRouter.get("/estimates/:estimateId", requiredAuth, driverController.getEstimateDetail);
+
+driverPrivateRouter.get(
+  "/estimate-requests/rejected",
+  requiredAuth,
+  driverController.getRejectedEstimateRequests
+);
+
+
 export default driverPrivateRouter;

--- a/src/services/driver.service.ts
+++ b/src/services/driver.service.ts
@@ -1,4 +1,3 @@
-import prisma from "../config/prisma";
 import driverRepository, { EditDataType, optionsType } from "../repositories/driver.repository";
 
 async function getAllDrivers(options: optionsType, userId?: string) {
@@ -22,13 +21,27 @@ async function getEstimateRequestsForDriver(driverId: string) {
 }
 
 async function findEstimateByDriverAndRequest(driverId: string, estimateRequestId: string) {
-  return prisma.estimate.findFirst({
-    where: { driverId, estimateRequestId, deletedAt: null }
-  });
+  return await driverRepository.findEstimateByDriverAndRequest(driverId, estimateRequestId);
 }
 
 async function createEstimate(data: { driverId: string; estimateRequestId: string; price: number; comment?: string }) {
-  return prisma.estimate.create({ data });
+  return await driverRepository.createEstimate(data);
+}
+
+async function rejectEstimate(estimateId: string, reason: string) {
+  return await driverRepository.rejectEstimate(estimateId, reason);
+}
+
+async function getMyEstimates(driverId: string) {
+  return await driverRepository.getMyEstimates(driverId);
+}
+
+async function getEstimateDetail(driverId: string, estimateId: string) {
+  return await driverRepository.getEstimateDetail(driverId, estimateId);
+}
+
+async function getRejectedEstimateRequests(driverId: string) {
+  return await driverRepository.getRejectedEstimateRequests(driverId);
 }
 
 export default {
@@ -38,5 +51,9 @@ export default {
   updateDriver,
   getEstimateRequestsForDriver,
   findEstimateByDriverAndRequest,
-  createEstimate
+  createEstimate,
+  rejectEstimate,
+  getMyEstimates,
+  getEstimateDetail,
+  getRejectedEstimateRequests
 };


### PR DESCRIPTION
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. `POST /driver/estimate-requests/:requestId/reject`  
   - 고객 견적 요청 반려 처리  
2. `GET /driver/estimates`  
   - 기사님이 보낸 견적 리스트 조회
3. `GET /driver/estimates/:estimateId`  
   - 보낸 견적 상세 조회  
4. `GET /driver/estimate-requests/rejected`  
   - 기사님이 반려한 견적 요청 리스트 조회

> 추후 프론트 연동 및 예외/권한 처리 보완 예정입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
