### PR TITLE
[FIX] 활성 견적 요청 조회 로직 수정 및 기사 응답 수 제한 추가

### DIFF
--- a/src/repositories/estimateReq.repository.ts
+++ b/src/repositories/estimateReq.repository.ts
@@ -32,12 +32,15 @@ async function findActiveEstimateRequest(customerId: string) {
     where: {
       customerId,
       deletedAt: null,
-      moveDate: {
-        gt: new Date()
-      },
-      status: {
-        in: ["PENDING", "APPROVED"]
-      }
+      OR: [
+        { status: "PENDING" },
+        {
+          status: "APPROVED",
+          moveDate: {
+            gt: new Date()
+          }
+        }
+      ]
     },
     include: { designatedDrivers: true } // 지정 요청 기사 목록 포함
   });


### PR DESCRIPTION
## 📝작업 내용
- 활성 견적 요청 조회 문제 해결
   - 활성 견적 요청 조회 시 PENDING, APPROVED 상태이며 이사일이 지나지 않은 요청만 반환하도록 조건 수정
   - 잘못된 활성 요청 반환으로 견적 요청 페이지가 비활성화되지 않는 문제 해결

- 기사 견적 응답 수 제한
   -  일반 기사 견적 응답 시 최대 5명 초과 시도 차단
   -  지정 견적 기사와는 다른 테이블로 분리해 최대 8명 기사의 견적을 받을 수 있도록 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
