### PR TITLE
fix: 이사 당일 견적 요청 불가하도록 수정

### DIFF
--- a/src/repositories/estimateReq.repository.ts
+++ b/src/repositories/estimateReq.repository.ts
@@ -1,6 +1,7 @@
 import prisma from "../config/prisma";
 import type { AddressRole, RegionType } from "@prisma/client";
 import { LinkCustomerAddressInput, CreateEstimateRequestInput } from "../types/estimateReq.type";
+import dayjs from "dayjs";
 
 // 고객(customer) 테이블에 연결(FROM, TO)
 async function linkCustomerAddress(data: LinkCustomerAddressInput) {
@@ -37,7 +38,7 @@ async function findActiveEstimateRequest(customerId: string) {
         {
           status: "APPROVED",
           moveDate: {
-            gt: new Date()
+            gte: dayjs().startOf("day").toDate()
           }
         }
       ]


### PR DESCRIPTION
## 📝작업 내용
- moveDate가 오늘(startOf day)이거나 이후인 경우 활성 견적으로 간주하여 추가 견적 요청 차단

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
