### PR TITLE
[Fix/logintoken 이지수] 토큰 설정값 통일

### DIFF
--- a/src/controllers/auth.controller.test.ts
+++ b/src/controllers/auth.controller.test.ts
@@ -5,6 +5,7 @@ import authRepository from "../repositories/auth.repository";
 import passport from "passport";
 import { CustomError } from "../utils/customError";
 import { UserType } from "@prisma/client";
+import { getCookieDomain } from "../utils/getCookieDomain";
 
 jest.mock("../services/auth.service");
 jest.mock("../repositories/auth.repository");
@@ -99,8 +100,9 @@ describe("AuthController", () => {
       expect(mockResponse.cookie).toHaveBeenCalledWith("refreshToken", loginResult.refreshToken, {
         httpOnly: true,
         path: "/",
-        sameSite: "none",
-        secure: true
+        sameSite: "lax",
+        secure: true,
+        domain: getCookieDomain()
       });
       expect(mockResponse.json).toHaveBeenCalledWith({ accessToken: loginResult.accessToken, user: loginResult.user });
       expect(mockNext).not.toHaveBeenCalled();
@@ -130,8 +132,9 @@ describe("AuthController", () => {
       expect(mockResponse.clearCookie).toHaveBeenCalledWith("refreshToken", {
         httpOnly: true,
         path: "/",
-        sameSite: "none",
-        secure: true
+        sameSite: "lax",
+        secure: true,
+        domain: getCookieDomain()
       });
       expect(mockResponse.status).toHaveBeenCalledWith(200);
       expect(mockResponse.json).toHaveBeenCalledWith({ message: "성공적으로 로그아웃되었습니다." });

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -6,6 +6,7 @@ import { asyncHandler } from "../utils/asyncHandler";
 import { UserType } from "@prisma/client";
 import rateLimit from "express-rate-limit";
 import { CustomError } from "../utils/customError";
+import { getCookieDomain } from "../utils/getCookieDomain";
 
 declare global {
   namespace Express {
@@ -59,8 +60,9 @@ const logIn = asyncHandler(async (req: Request, res: Response) => {
   res.cookie("refreshToken", refreshToken, {
     httpOnly: true,
     path: "/",
-    sameSite: "none",
-    secure: true
+    sameSite: "lax",
+    secure: true,
+    domain: getCookieDomain()
   });
 
   res.json({ accessToken, user });
@@ -71,8 +73,9 @@ const logOut = asyncHandler(async (_req: Request, res: Response) => {
   res.clearCookie("refreshToken", {
     httpOnly: true,
     path: "/",
-    sameSite: "none",
-    secure: true
+    sameSite: "lax",
+    secure: true,
+    domain: getCookieDomain()
   });
   res.status(200).json({ message: "성공적으로 로그아웃되었습니다." });
 });
@@ -128,17 +131,19 @@ const socialLoginCallback = (req: Request, res: Response, next: NextFunction) =>
 
         res.cookie("accessToken", accessToken, {
           httpOnly: false,
-          sameSite: "none",
+          sameSite: "lax",
           secure: true,
-          maxAge: 15 * 60 * 1000
+          maxAge: 15 * 60 * 1000,
+          domain: getCookieDomain()
         });
 
         // refreshToken은 기존대로 httpOnly 쿠키로 저장
         res.cookie("refreshToken", refreshToken, {
           httpOnly: true,
           path: "/",
-          sameSite: "none",
-          secure: true
+          sameSite: "lax",
+          secure: true,
+          domain: getCookieDomain()
         });
 
         // 로그인 성공 후 클라이언트 메인 페이지로 리다이렉트

--- a/src/controllers/profile.controller.test.ts
+++ b/src/controllers/profile.controller.test.ts
@@ -3,6 +3,7 @@ import profileController from "./profile.controller";
 import profileService from "../services/profile.service";
 import { CustomError } from "../utils/customError";
 import { UserType, MoveType, RegionType } from "@prisma/client";
+import { getCookieDomain } from "../utils/getCookieDomain";
 
 jest.mock("../services/profile.service");
 
@@ -75,8 +76,9 @@ describe("ProfileController", () => {
       expect(mockResponse.cookie).toHaveBeenCalledWith("refreshToken", serviceResult.refreshToken, {
         httpOnly: true,
         path: "/",
-        sameSite: "none",
-        secure: true
+        sameSite: "lax",
+        secure: true,
+        domain: getCookieDomain()
       });
       expect(mockResponse.status).toHaveBeenCalledWith(201);
       expect(mockResponse.json).toHaveBeenCalledWith({
@@ -147,8 +149,9 @@ describe("ProfileController", () => {
       expect(mockResponse.cookie).toHaveBeenCalledWith("refreshToken", serviceResult.refreshToken, {
         httpOnly: true,
         path: "/",
-        sameSite: "none",
-        secure: true
+        sameSite: "lax",
+        secure: true,
+        domain: getCookieDomain()
       });
       expect(mockResponse.status).toHaveBeenCalledWith(201);
       expect(mockResponse.json).toHaveBeenCalledWith({

--- a/src/controllers/profile.controller.ts
+++ b/src/controllers/profile.controller.ts
@@ -3,6 +3,7 @@ import { asyncHandler } from "../utils/asyncHandler";
 import { CustomError } from "../utils/customError";
 import profileService from "../services/profile.service";
 import { UserType } from "@prisma/client";
+import { getCookieDomain } from "../utils/getCookieDomain";
 
 declare global {
   namespace Express {
@@ -47,8 +48,9 @@ const createCustomerProfile = asyncHandler(async (req: Request, res: Response) =
   res.cookie("refreshToken", refreshToken, {
     httpOnly: true,
     path: "/",
-    sameSite: "none",
-    secure: true
+    sameSite: "lax",
+    secure: true,
+    domain: getCookieDomain()
   });
   res.status(201).json({ profile, accessToken });
 });
@@ -111,7 +113,13 @@ const createDriverProfile = asyncHandler(async (req: Request, res: Response) => 
     serviceAreas
   });
 
-  res.cookie("refreshToken", refreshToken, { httpOnly: true, path: "/", sameSite: "none", secure: true });
+  res.cookie("refreshToken", refreshToken, {
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+    secure: true,
+    domain: getCookieDomain()
+  });
 
   res.status(201).json({ profile, accessToken });
 });

--- a/src/utils/getCookieDomain.ts
+++ b/src/utils/getCookieDomain.ts
@@ -1,0 +1,11 @@
+export const getCookieDomain = (): string | undefined => {
+  const clientUrl = process.env.CLIENT_URL ?? "";
+
+  // 로컬 개발 환경이면 domain 생략
+  if (clientUrl.includes("localhost")) {
+    return undefined;
+  }
+
+  // 배포 환경이면 .도메인 형식
+  return ".moving-2.click";
+};


### PR DESCRIPTION
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존에 프론트에서 발급받던 쿠키는 프론트도메인인 www.moving-2.click로 발급되고 백엔드에서 발급받는 쿠키는 api.moving-2.click 형식으로 브라우저에서 자동으로 발급받고 있었는데 이걸통일시켜서 에러를 해결하고 리프레쉬랑 액세스토큰 쿠키설정값도 모든곳에서 통일하였음.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
